### PR TITLE
feat: Add initial support for filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Update toolchains
-      run: rustup update stable && rustup default stable
+      run: |
+        rustup update stable
+        rustup update nightly
+        rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
+        rustup default stable
     - name: Check formatting
-      run: cargo fmt --all -- --check
+      run: cargo +nightly fmt --all --check
     - name: Run unit tests
       run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,11 +3,27 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "envsub"
 version = "0.1.0"
 dependencies = [
- "nom",
+ "lazy_static",
+ "regex",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "memchr"
@@ -16,17 +32,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
+name = "regex"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
 
 [[package]]
-name = "nom"
-version = "7.1.3"
+name = "regex-syntax"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ name = "envsub"
 version = "0.1.0"
 
 [dependencies]
-nom = "7.1.3"
+lazy_static = "1.4.0"
+regex = "1.8.1"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # envsub
 
+**WIP**
+
 Environment variable substitution.
 
 ## Getting started
@@ -19,6 +21,8 @@ spec:
   containers:
   - image: nginx:${NGINX_VERSION}
     name: nginx
+    ports:
+    - containerPort: ${PORT | default(80)}
     restartPolicy: Never
 ```
 
@@ -35,6 +39,8 @@ spec:
   containers:
   - image: nginx:1.23.4
     name: nginx
+    ports:
+    - containerPort: 80
     restartPolicy: Never
 ```
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,17 @@
+binop_separator = "Back"
+fn_single_line = true
+format_strings = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+imports_layout = "HorizontalVertical"
+match_block_trailing_comma = true
+max_width = 80
+newline_style = "Unix"
+reorder_impl_items = true
+reorder_imports = true
+reorder_modules = true
+trailing_comma = "Vertical"
+trailing_semicolon = false
+use_field_init_shorthand = true
+use_try_shorthand = true
+wrap_comments = true

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,41 @@
+// Copyright © 2023 Daniel Morris
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub fn apply_filters(
+    input: &str,
+    filters: &[(String, Option<String>)],
+) -> String {
+    filters
+        .iter()
+        .fold(input.to_string(), |input, (filter, arg)| {
+            match filter.as_str() {
+                "uppercase" => uppercase(&input),
+                "lowercase" => lowercase(&input),
+                "default" => default(&input, arg.as_deref()),
+                _ => input,
+            }
+        })
+}
+
+fn uppercase(input: &str) -> String { input.to_uppercase() }
+
+fn lowercase(input: &str) -> String { input.to_lowercase() }
+
+fn default(input: &str, value: Option<&str>) -> String {
+    if input.is_empty() {
+        value.unwrap_or("").to_string()
+    } else {
+        input.to_string()
+    }
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,50 @@
+// Copyright © 2023 Daniel Morris
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref VARIABLE_REGEX: Regex = Regex::new(r"\$\{(.+?)\}").unwrap();
+    static ref FILTER_REGEX: Regex =
+        Regex::new(r"([^()\s]+)\(([^()]*)\)").unwrap();
+}
+
+type Placeholder = Vec<(String, String, Vec<(String, Option<String>)>)>;
+
+pub fn find_variables(input: &str) -> Placeholder {
+    VARIABLE_REGEX
+        .captures_iter(input)
+        .map(|v| {
+            let placeholder = v[0].to_string();
+            let contents = v[1].trim();
+            let mut parts = contents.split('|').map(|s| s.trim().to_string());
+
+            let name = parts.next().unwrap_or_default();
+            let filters = parts.map(parse_filter).collect();
+
+            (placeholder, name, filters)
+        })
+        .collect()
+}
+
+fn parse_filter(input: String) -> (String, Option<String>) {
+    if let Some(filter) = FILTER_REGEX.captures(&input) {
+        let name = filter[1].to_string();
+        let arg = Some(filter[2].to_string().trim().replace('\"', ""));
+        (name, arg)
+    } else {
+        (input, None)
+    }
+}


### PR DESCRIPTION
Replaces nom with two regexes for the time being since this is simpler, and makes an attempt at the first iteration of filters.